### PR TITLE
Add start function

### DIFF
--- a/LoadRemover/SB-AutoSplitter.asl
+++ b/LoadRemover/SB-AutoSplitter.asl
@@ -2,11 +2,13 @@ state("SB-Win64-Shipping", "current")
 {
     // patch 1.2.0
     bool isLoading : 0x7103D20;
+    int titleScreen : 0x710B4E4;
 }
 
 state("SB-Win64-Shipping", "1.1.0")
 {
     bool isLoading : 0x6D83DEC;
+    int titleScreen : 0x7105438;
 }
 
 init
@@ -22,3 +24,14 @@ isLoading
     return current.isLoading;
 }
 
+start
+{
+    if (
+        (current.titleScreen == 48 || current.titleScreen == 54)
+        && (old.titleScreen + 1) == current.titleScreen
+    ) {
+        // 47 to 48 -- press continue
+        // 53 to 54 -- new game or new game plus
+        return true;
+    }
+}


### PR DESCRIPTION
Uses address that increments by 1 when starting the game.
This address increments by 1 at multiple points in the game, so we need to contain the check to only the values we know are "starting" the game